### PR TITLE
Add witx-codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ A collection of useful, language-agnostic WebAssembly development tools.
 - **wasm-debug** | [repo](https://github.com/wasmerio/wasm-debug), [crate](https://crates.io/crates/wasm-debug)  
   A runtime-independent Rust library that provides functionality to read, transform, and write DWARF section.
 
+- **witx-codegen** | [repo](https://github.com/jedisct1/witx-codegen)
+  A code generator to access WebAssembly standard APIs from different programming languages. Can also generate documentation.
+
 - **Articles**
   - [Fuzzers & Reducers as Productivity Tools](https://kripken.github.io/blog/binaryen/2019/06/11/fuzz-reduce-productivity.html)
 


### PR DESCRIPTION
`witx-codegen` (previously `as-witx`) is a tool to create code and documentation from WITX files, that describe standard WebAssembly ABIs (WASI).