### PR TITLE
Add Remove Audio — real-world FFmpeg.wasm tool for browser video processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of useful, language-agnostic WebAssembly development tools.
 [<img height="100" src="/images/wasm3-strace.png">](https://raw.githubusercontent.com/vshymanskyy/awesome-wasm-tools/main/images/wasm3-strace.png)
 [<img height="100" src="/images/chrome-dev-tools.png">](https://raw.githubusercontent.com/vshymanskyy/awesome-wasm-tools/main/images/chrome-dev-tools.png)
 
-ð Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTING.md). ð
+👉 Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTING.md). 😎
 
 
 ## Inspecting

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of useful, language-agnostic WebAssembly development tools.
 [<img height="100" src="/images/wasm3-strace.png">](https://raw.githubusercontent.com/vshymanskyy/awesome-wasm-tools/main/images/wasm3-strace.png)
 [<img height="100" src="/images/chrome-dev-tools.png">](https://raw.githubusercontent.com/vshymanskyy/awesome-wasm-tools/main/images/chrome-dev-tools.png)
 
-👉 Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTING.md). 😎
+ð Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTING.md). ð
 
 
 ## Inspecting
@@ -150,5 +150,6 @@ A collection of useful, language-agnostic WebAssembly development tools.
 
 
 ## Other
+- [Remove Audio](https://remove-audio.com) - Browser tool that strips audio from video files using FFmpeg.wasm. No server, no uploads. Batch up to 20 clips. Real-world WebAssembly in production.
 
 - **WebAssembly Opcode Table** | [docs](https://pengowray.github.io/wasm-ops/)  


### PR DESCRIPTION
A production application of WebAssembly: [Remove Audio](https://remove-audio.com) uses FFmpeg.wasm to strip audio from video files entirely in the browser. No server-side processing, no uploads. Users drop a video in, processing happens in-tab via WASM, they download the muted file.

Technical notes:
- Uses FFmpeg.wasm with SharedArrayBuffer + COOP/COEP headers
- Handles Safari iOS WASM heap limits
- Sequential job queue for batch processing up to 20 files